### PR TITLE
Unknown option var name fix

### DIFF
--- a/kali.sh
+++ b/kali.sh
@@ -111,7 +111,7 @@ while [[ "${#}" -gt 0 && ."${1}" == .-* ]]; do
     -timezone=*|--timezone=* )
        timezone="${opt#*=}";;
 
-    *) echo -e ' '${RED}'[!]'${RESET}" Unknown option: ${RED}${x}${RESET}" 1>&2 && exit 1;;
+    *) echo -e ' '${RED}'[!]'${RESET}" Unknown option: ${RED}${opt}${RESET}" 1>&2 && exit 1;;
    esac
 done
 


### PR DESCRIPTION
Previously if you gave an invalid option, it would not
print the incorrect option since it was referring to an
older variable name (x) instead of the current (opt)

When invoking with `-foo`

Previously:
```
+ echo -e ' \033[01;31m[!]\033[00m Unknown option: \033[01;31m\033[00m'
[!] Unknown option:
+ exit 1
```

Now:
```
+ echo -e ' \033[01;31m[!]\033[00m Unknown option:\033[01;31m-foo\033[00m'
[!] Unknown option: -foo
+ exit 1
```